### PR TITLE
Add redocly viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,10 @@
     />
   </head>
   <body>
-    <redoc spec-url="bblrm-specification.yaml" style="height: 400px"></redoc>
+    <!--
+      Disable search because of https://github.com/Redocly/redoc/issues/1362#issuecomment-860873912
+    -->
+    <redoc spec-url="bblrm-specification.yaml" style="height: 400px" disable-search="true"></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bokbasen LRM API</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      redoc {
+        display: block;
+      }
+    </style>
+    <link
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <redoc spec-url="bblrm-specification.yaml" style="height: 400px"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
A simple static viewer that can be used with GitHub Pages. 

Note:
* No cache busting technique, so the spec file may be cached client side for some time
* Use Redocly CDN at your own risk. I find it fine to use during prototyping and development, and could be replaced by a local build later.